### PR TITLE
Replace application/text with text/plain

### DIFF
--- a/codecovopentelem/__init__.py
+++ b/codecovopentelem/__init__.py
@@ -137,7 +137,7 @@ class CoverageExporter(SpanExporter):
         location = res.json()["raw_upload_location"]
         requests.put(
             location,
-            headers={"Content-Type": "application/txt"},
+            headers={"Content-Type": "text/plain"},
             data=json.dumps(
                 {"spans": tracked_spans, "untracked": untracked_spans}
             ).encode(),


### PR DESCRIPTION
`application/text` isn't a valid MIME (see https://github.com/codecov/laravel-codecov-opentelemetry/pull/21)